### PR TITLE
with logtype prefix for custom logger

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -525,7 +525,8 @@ export class CustomLoggerTool implements ICustomLogger {
     }
 
     // Needs to be implemented
-    public sendLog(content: any): void {
+    public sendLog(content: any, prefix: string): void {
+        // prefix is either: INFO | ERROR | WARNING | IMPORTANT
         this.thirdPartyLoggingApplication.doStuff(content);
     }
 }

--- a/src/logger/lib/Logger.ts
+++ b/src/logger/lib/Logger.ts
@@ -265,7 +265,7 @@ export class Logger {
             Logger.WriteToFile(logType.prefix + content + '\n', filePath);
         } else if (mode === LoggerModes.Custom) {
             if (customLogger) {
-                customLogger.sendLog(content);
+                customLogger.sendLog(content, logType.prefix);
             } else {
                 throw Error(Logger.CUSTOM_LOGGER_ERR);
             }

--- a/src/logger/lib/constants.ts
+++ b/src/logger/lib/constants.ts
@@ -31,7 +31,7 @@ export type LoggerModeOptions = LoggerModes.Console | LoggerModes.File | LoggerM
  **********************************************************************************************/
 
 export interface ICustomLogger {
-    sendLog(content: any): void;
+    sendLog(content: any, prefix: string): void;
 }
 
 


### PR DESCRIPTION
I would like the ability to know what type of log the content if for when implementing a third party logger to hook into the overnight logger.

It looks like the ILogType prefix is useful for this so that I can decide to call the third party's info(), error(), warning(), etc... respective method.  I don't have this information just from the 'content' parameter.