### PR TITLE
feat: Allow paths to start with a forward slash

### DIFF
--- a/src/core/lib/decorators/class.ts
+++ b/src/core/lib/decorators/class.ts
@@ -10,7 +10,8 @@ import {classMetadataKey, Controller, IClassMetadata} from './types';
 
 export function Controller(path: string): ClassDecorator {
     return <TFunction extends Function>(target: TFunction): void => {
-        addBasePathToClassMetadata(target.prototype, '/' + path);
+        const computedPath: string = path.charAt(0) === '/' ? path : '/' + path;
+        addBasePathToClassMetadata(target.prototype, computedPath);
     };
 }
 

--- a/src/core/lib/decorators/method.spec.ts
+++ b/src/core/lib/decorators/method.spec.ts
@@ -6,6 +6,7 @@ import {
     AllVerbController,
     HeadController,
     MultipleVerbDecoratorsController, NonControllerChildController,
+    PathMatchingController,
     RegExpController,
     SimpleController, UndecoratedPropertiesController, UnmarkedMethodController,
 } from '../../test/lib/controllers';
@@ -23,6 +24,7 @@ describe('Method Decorators', () => {
             app.addControllers([
                 new AllHttpVerbsController(),
                 new AllVerbController(),
+                new PathMatchingController(),
                 new HeadController(),
                 new MultipleVerbDecoratorsController(),
                 new SimpleController(),
@@ -53,6 +55,10 @@ describe('Method Decorators', () => {
 
         it('should be able to decorate properties that are functions', async () => {
             await SimpleController.validateWrapperOnProperty();
+        });
+
+        it('should match paths starting with a forward slash', async () => {
+            await PathMatchingController.validateAll();
         });
 
         describe('Regex', () => {

--- a/src/core/lib/decorators/method.ts
+++ b/src/core/lib/decorators/method.ts
@@ -111,7 +111,7 @@ function helperForRoutes(httpVerb: HttpDecorator, path?: string | RegExp): Metho
         } else if (path instanceof RegExp) {
             newPath = addForwardSlashToFrontOfRegex(path);
         } else { // assert (path instanceof string)
-            newPath = '/' + path;
+            newPath = path.charAt(0) === '/' ? path : '/' + path;
         }
         addHttpVerbToMethodMetadata(target, propertyKey, httpVerb, newPath);
     };

--- a/src/core/package-lock.json
+++ b/src/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@overnightjs/core",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "lint": "./node_modules/.bin/tslint **/*.ts --exclude node_modules/**",
-    "test": "./node_modules/.bin/ts-mocha **/*.spec.ts",
+    "test": "./node_modules/.bin/ts-mocha '**/*.spec.ts'",
     "coverage": "./node_modules/.bin/nyc --reporter=text --reporter=html npm run test"
   },
   "repository": {

--- a/src/core/test/lib/controllers/PathMatchingController.ts
+++ b/src/core/test/lib/controllers/PathMatchingController.ts
@@ -1,0 +1,58 @@
+/**
+ * Class to test if controllers and
+ * controller methods are correctly matched
+ * regardless if they have a forward slash or not.
+ */
+import { Request, Response } from 'express';
+import { OK } from 'http-status-codes';
+
+import { assertRequest } from '../helpers';
+import { Get, Post, Controller } from '../../../lib';
+import { HttpVerb } from '../../../lib/decorators/types';
+
+@Controller('/path')
+export class PathMatchingController {
+
+
+    @Get('/forward-slash')
+    public get(req: Request, res: Response): any {
+        return res.status(OK).json({
+            message: 'forwardSlash',
+        });
+    }
+
+
+    @Post('/forward-slash')
+    public post(req: Request, res: Response): any {
+        return res.status(OK).json({
+            message: 'forwardSlash',
+        });
+    }
+
+
+    @Get('no-forward-slash')
+    public noForwardSlash(req: Request, res: Response): any {
+        return res.status(OK).json({
+            message: 'forwardSlash',
+        });
+    }
+
+
+    public static async validateAll(): Promise<void> {
+        type ExecuteRequest = (verb: HttpVerb, path: string) => Promise<void>;
+        const request: ExecuteRequest = (verb: HttpVerb, path: string): Promise<void> => (
+          assertRequest(path, verb, {
+            body: { message: 'forwardSlash' },
+            status: OK,
+          }
+        ));
+
+        await Promise.all([
+          request(HttpVerb.GET, '/path/forward-slash'),
+          request(HttpVerb.POST, '/path/forward-slash'),
+          request(HttpVerb.GET, '/path/no-forward-slash')
+        ]);
+    }
+
+}
+

--- a/src/core/test/lib/controllers/index.ts
+++ b/src/core/test/lib/controllers/index.ts
@@ -11,6 +11,7 @@ export * from './MethodWrapperController';
 export * from './MultipleVerbDecoratorsController';
 export * from './ParentsAndChildControllers';
 export * from './ParentsAndChildren';
+export * from './PathMatchingController';
 export * from './RegExpController';
 export * from './SimpleController';
 export * from './UnexpectedBehaviorControllers';

--- a/src/core/test/lib/helpers.ts
+++ b/src/core/test/lib/helpers.ts
@@ -19,7 +19,6 @@ export async function assertRequest(path: string, method: HttpVerb, expected: Ob
         assert.fail(`Threw error making request to and parsing body from ${method.toUpperCase()} ${path}.`);
     }
     assert.deepEqual<Object>(
-        // @ts-ignore
         response, // Guaranteed to be initialized because assert.fail(...) always throws an error
         expected,
         `${method.toUpperCase()} ${path} returned unexpected response.`,


### PR DESCRIPTION
This PR allows paths to be prefixed with a forward slash for Controllers and method decorators. 

The current implementation was always adding a forward slash, regardless if it was already there - which caused routes such as `@Get('/foo')` not to be matched, for example. 

Changing this behavior would make Overnight more consistent with the "patch matching" strategies used by most other frameworks and libraries. 

--

Great library, by the way! I was implementing a similar solution and was very pleased to find out about overnight!

