### PR TITLE
set HS256

### DIFF
--- a/src/jwt/lib/JwtManager.ts
+++ b/src/jwt/lib/JwtManager.ts
@@ -76,6 +76,7 @@ export class JwtManager {
         const options = {
             secret,
             userProperty: 'payload',
+            algorithms: ['HS256']
         };
 
         return expressJwt(options);


### PR DESCRIPTION
This solves  JWT Middleware #69.

The new version of expressJwt requires to be explicit and set the algorithm.
HS256 was the dafault algo before: https://stackoverflow.com/questions/62665636/if-options-algorithms-throw-new-erroralgorithms-should-be-set-error-alg