### PR TITLE
Use explicit tslib dependency

### DIFF
--- a/src/logger/package.json
+++ b/src/logger/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "colors": "^1.3.3",
-    "util": "^0.11.1"
+    "util": "^0.11.1",
+    "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^11.13.0",


### PR DESCRIPTION
Current code uses TS helpers, but does not depend on tslib package. This PR provides a fix by declaring tslib dependency.