### PR TITLE
feat(core): allow controller decorator with multi endpoints

### DIFF
--- a/src/core/lib/decorators/class.ts
+++ b/src/core/lib/decorators/class.ts
@@ -8,9 +8,9 @@
 import {RouterOptions} from 'express';
 import {classMetadataKey, Controller, IClassMetadata} from './types';
 
-export function Controller(path: string): ClassDecorator {
+export function Controller(path: string | string[]): ClassDecorator {
     return <TFunction extends Function>(target: TFunction): void => {
-        addBasePathToClassMetadata(target.prototype, '/' + path);
+        addBasePathToClassMetadata(target.prototype, path);
     };
 }
 
@@ -34,12 +34,20 @@ export function ChildControllers(children: Controller | Controller[]): ClassDeco
     };
 }
 
-export function addBasePathToClassMetadata(target: Object, basePath: string): void {
+export function addBasePathToClassMetadata(target: Object, basePath: string | string[]): void {
     let metadata: IClassMetadata | undefined = Reflect.getOwnMetadata(classMetadataKey, target);
     if (!metadata) {
         metadata = {};
     }
-    metadata.basePath = basePath;
+    
+    let pathArr: string[];
+    if (basePath instanceof Array) {
+        pathArr = basePath.slice();
+    } else {
+        pathArr = [basePath];
+    }
+
+    metadata.basePath = pathArr.map(path => '/' + path);
     Reflect.defineMetadata(classMetadataKey, metadata, target);
 }
 

--- a/src/core/lib/decorators/class.ts
+++ b/src/core/lib/decorators/class.ts
@@ -40,14 +40,11 @@ export function addBasePathToClassMetadata(target: Object, basePath: string | st
         metadata = {};
     }
     
-    let pathArr: string[];
-    if (basePath instanceof Array) {
-        pathArr = basePath.slice();
-    } else {
-        pathArr = [basePath];
+    if (!(basePath instanceof Array)) {
+        basePath = [basePath];
     }
 
-    metadata.basePath = pathArr.map(path => '/' + path);
+    metadata.basePath = basePath.map(path => '/' + path);
     Reflect.defineMetadata(classMetadataKey, metadata, target);
 }
 


### PR DESCRIPTION
Allow to create a controller decorator with multi endpoints just like [NestJS](https://github.com/nestjs/nest/blob/149483a852a70f0b095997450889442ed93bc3b8/packages/common/decorators/core/controller.decorator.ts#L77) does

Current behavior 
```js
// endpoints: /users/:id
@Controller("users")
export class UserController {
    @Get(":id")
    public async getOneUser() {
        // Logic here
    }
}
```
New behavior
```js
// if you need just one endpoint:
// endpoints: /users/:id
@Controller("users")
export class UserController {
    @Get(":id")
    public async getOneUser() {
        // Logic here
    }
}

// if you need multiple endpoints:
// endpoints: /users/:id AND /potato/:id
@Controller(["users", "potato"])
export class UserController {
    @Get(":id")
    public async getOneUser() {
        // Logic here
    }
}
```
Related Issues:
#97 